### PR TITLE
인증정보가 필요하지 않은 퀴즈 조회 api 작성

### DIFF
--- a/backend/src/main/java/com/morjo/config/DBConfig.java
+++ b/backend/src/main/java/com/morjo/config/DBConfig.java
@@ -1,0 +1,12 @@
+package com.morjo.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@MapperScan(basePackages = "com.morjo.model.dao")
+public class DBConfig {
+    public static void main(String[] args) {
+
+    }
+}

--- a/backend/src/main/java/com/morjo/controller/QuizController.java
+++ b/backend/src/main/java/com/morjo/controller/QuizController.java
@@ -1,0 +1,30 @@
+package com.morjo.controller;
+
+import com.morjo.model.dto.Quiz;
+import com.morjo.model.service.QuizService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/quiz")
+public class QuizController {
+    private final QuizService quizService;
+
+    @GetMapping("/{quizId}")
+    public ResponseEntity<?> findSpecificQuiz(@PathVariable("quizId") int quizId) {
+        Quiz quiz = quizService.findQuizById(quizId);
+
+        if (quiz == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 번호의 퀴즈가 없습니다");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(quiz);
+    }
+
+}

--- a/backend/src/main/java/com/morjo/controller/QuizController.java
+++ b/backend/src/main/java/com/morjo/controller/QuizController.java
@@ -1,6 +1,7 @@
 package com.morjo.controller;
 
 import com.morjo.model.dto.Quiz;
+import com.morjo.model.dto.QuizResult;
 import com.morjo.model.service.QuizService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,10 +22,21 @@ public class QuizController {
         Quiz quiz = quizService.findQuizById(quizId);
 
         if (quiz == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 번호의 퀴즈가 없습니다");
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 번호의 퀴즈를 찾을 수 없습니다");
         }
 
         return ResponseEntity.status(HttpStatus.OK).body(quiz);
+    }
+
+    @GetMapping("/{quizId}/result")
+    public ResponseEntity<?> getQuizResult(@PathVariable("quizId") int quizId) {
+        QuizResult result = quizService.getQuizResultById(quizId);
+
+        if (result == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 번호의 퀴즈를 찾을 수 없습니다");
+        }
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
 }

--- a/backend/src/main/java/com/morjo/model/dao/QuizDao.java
+++ b/backend/src/main/java/com/morjo/model/dao/QuizDao.java
@@ -1,0 +1,7 @@
+package com.morjo.model.dao;
+
+import com.morjo.model.dto.Quiz;
+
+public interface QuizDao {
+    Quiz selectQuizById(long quizId);
+}

--- a/backend/src/main/java/com/morjo/model/dao/QuizDao.java
+++ b/backend/src/main/java/com/morjo/model/dao/QuizDao.java
@@ -1,7 +1,9 @@
 package com.morjo.model.dao;
 
 import com.morjo.model.dto.Quiz;
+import com.morjo.model.dto.QuizResult;
 
 public interface QuizDao {
     Quiz selectQuizById(long quizId);
+    QuizResult selectQuizResultById(long quizId);
 }

--- a/backend/src/main/java/com/morjo/model/dto/Quiz.java
+++ b/backend/src/main/java/com/morjo/model/dto/Quiz.java
@@ -1,0 +1,22 @@
+package com.morjo.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+public class Quiz {
+    private long quizId;
+    private String content;
+    private List<String> options = new ArrayList<>();
+    private int answer;
+    private long createdUserId;
+    private Timestamp createdAt;
+
+    public void setOptions(String option) {
+        options.add(option);
+    }
+}

--- a/backend/src/main/java/com/morjo/model/dto/Quiz.java
+++ b/backend/src/main/java/com/morjo/model/dto/Quiz.java
@@ -12,7 +12,6 @@ public class Quiz {
     private long quizId;
     private String content;
     private List<String> options = new ArrayList<>();
-    private int answer;
     private long createdUserId;
     private Timestamp createdAt;
 

--- a/backend/src/main/java/com/morjo/model/dto/QuizResult.java
+++ b/backend/src/main/java/com/morjo/model/dto/QuizResult.java
@@ -1,0 +1,6 @@
+package com.morjo.model.dto;
+public class QuizResult {
+    public static void main(String[] args) {
+        
+    }
+}

--- a/backend/src/main/java/com/morjo/model/dto/QuizResult.java
+++ b/backend/src/main/java/com/morjo/model/dto/QuizResult.java
@@ -1,6 +1,21 @@
 package com.morjo.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
 public class QuizResult {
-    public static void main(String[] args) {
-        
+    private long quizId;
+    private int answer;
+    private List<Integer> userAnswers = new ArrayList<>();
+    private int isCommonSense;
+    private int notCommonSense;
+
+    public void setUserAnswers(int count) {
+        userAnswers.add(count);
     }
 }

--- a/backend/src/main/java/com/morjo/model/service/QuizService.java
+++ b/backend/src/main/java/com/morjo/model/service/QuizService.java
@@ -1,0 +1,16 @@
+package com.morjo.model.service;
+
+import com.morjo.model.dao.QuizDao;
+import com.morjo.model.dto.Quiz;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class QuizService {
+    private final QuizDao quizDao;
+
+    public Quiz findQuizById(long quizId) {
+        return quizDao.selectQuizById(quizId);
+    }
+}

--- a/backend/src/main/java/com/morjo/model/service/QuizService.java
+++ b/backend/src/main/java/com/morjo/model/service/QuizService.java
@@ -2,6 +2,7 @@ package com.morjo.model.service;
 
 import com.morjo.model.dao.QuizDao;
 import com.morjo.model.dto.Quiz;
+import com.morjo.model.dto.QuizResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,5 +13,9 @@ public class QuizService {
 
     public Quiz findQuizById(long quizId) {
         return quizDao.selectQuizById(quizId);
+    }
+
+    public QuizResult getQuizResultById(long quizId) {
+        return quizDao.selectQuizResultById(quizId);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,5 +8,5 @@ spring.datasource.password=morjo1234
 
 # mybatis-config
 mybatis.mapper-locations=classpath:mappers/*.xml
-mybatis.type-aliases-package=com.morjo.mvc.model.dto
+mybatis.type-aliases-package=com.morjo.model.dto
 mybatis.configuration.map-underscore-to-camel-case=true

--- a/backend/src/main/resources/mappers/QuizMapper.xml
+++ b/backend/src/main/resources/mappers/QuizMapper.xml
@@ -9,8 +9,31 @@
         <result property="options" column="option3" />
         <result property="options" column="option4" />
     </resultMap>
+    <resultMap id="QuizResultMap" type="QuizResult">
+        <id property="quizId" column="quiz_id" />
+        <result property="userAnswers" column="answer1" />
+        <result property="userAnswers" column="answer2" />
+        <result property="userAnswers" column="answer3" />
+        <result property="userAnswers" column="answer4" />
+    </resultMap>
+
     <select id="selectQuizById" parameterType="long" resultMap="QuizMap">
         SELECT * FROM quiz
         WHERE quiz_id = #{quizId}
+    </select>
+    <select id="selectQuizResultById" parameterType="long" resultMap="QuizResultMap">
+        SELECT quiz_id,
+               (SELECT answer
+                FROM quiz
+                WHERE quiz.quiz_id = quiz_result.quiz_id)      AS answer,
+               COUNT(CASE WHEN user_answer = 1 THEN 1 END)     AS answer1,
+               COUNT(CASE WHEN user_answer = 2 THEN 1 END)     AS answer2,
+               COUNT(CASE WHEN user_answer = 3 THEN 1 END)     AS answer3,
+               COUNT(CASE WHEN user_answer = 4 THEN 1 END)     AS answer4,
+               COUNT(CASE WHEN is_common_sense = 1 THEN 1 END) AS isCommonSense,
+               COUNT(CASE WHEN is_common_sense = 1 THEN 1 END) AS notCommonSense
+        FROM (SELECT *
+              FROM quiz_user
+              WHERE quiz_id = #{quizId}) as `quiz_result`
     </select>
 </mapper>

--- a/backend/src/main/resources/mappers/QuizMapper.xml
+++ b/backend/src/main/resources/mappers/QuizMapper.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.morjo.model.dao.QuizDao">
+    <resultMap id="QuizMap" type="Quiz">
+        <id property="quizId" column="quiz_id" />
+        <result property="options" column="option1" />
+        <result property="options" column="option2" />
+        <result property="options" column="option3" />
+        <result property="options" column="option4" />
+    </resultMap>
+    <select id="selectQuizById" parameterType="long" resultMap="QuizMap">
+        SELECT * FROM quiz
+        WHERE quiz_id = #{quizId}
+    </select>
+</mapper>


### PR DESCRIPTION
## 작업내용
- 특정 퀴즈 조회 : `quizId`로 퀴즈 정보를 가져옵니다(정답 제외)
- 퀴즈 결과 조회 : `quizId`로 선지별 선택 유저 수와, 상식 비상식 투표수를 가져옵니다

- 나머지 퀴즈 관련 api들은 유저 정보가 필요해, 프론트 기본 작업 후에 할 예정

## 특이사항
- `mapper`를 작성하는 과정에서 `Quiz.setOptions`와 `QuizResult.setUserAnsers`를 일반적인 `setter`와 다르게 사용해서 나중에 혼동이 생길 수 있을 것 같습니다. 추후에 가능하다면 수정하려고 합니다.