### PR TITLE
회원가입 관련 핫픽스

### DIFF
--- a/backend/src/main/java/com/morjo/controller/UserController.java
+++ b/backend/src/main/java/com/morjo/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
         if (success) {
             session.removeAttribute("kakaoId");
             session.setAttribute("userId", user.getUserId());
-            ResponseEntity.status(HttpStatus.CREATED).build();
+            return ResponseEntity.status(HttpStatus.CREATED).build();
         }
 
         return ResponseEntity.status(HttpStatus.CONFLICT).body("중복된 닉네임입니다");

--- a/frontend/src/api/userApi.js
+++ b/frontend/src/api/userApi.js
@@ -2,7 +2,7 @@ import api from '@/api/api.js'
 
 export const postJoin = async (nickname) => {
   try {
-    const response = await api.post("/join", { nickname })
+    const response = await api.post('/user/join', { nickname })
     return response.data;
   } catch (e) {
     console.error(e)


### PR DESCRIPTION
## 수정사항
- `UserController`에 정상가입시 return문 없어 수정
- 프론트에서 회원가입 api주소 `join` -> `user/join`으로 수정