### PR TITLE
로그아웃, 유저관련 오류 수정

### DIFF
--- a/backend/src/main/java/com/morjo/controller/LoginController.java
+++ b/backend/src/main/java/com/morjo/controller/LoginController.java
@@ -60,6 +60,6 @@ public class LoginController {
         }
 
         session.removeAttribute("userId");
-        return ResponseEntity.status(HttpStatus.OK).body("로그인 완료");
+        return ResponseEntity.status(HttpStatus.OK).body("로그아웃 완료");
     }
 }

--- a/backend/src/main/java/com/morjo/controller/UserController.java
+++ b/backend/src/main/java/com/morjo/controller/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CONFLICT).body("중복된 닉네임입니다");
     }
 
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<?> getUser(HttpSession session) {
         Long userId = (Long) session.getAttribute("userId");
 


### PR DESCRIPTION
## 수정사항
- 로그아웃시 메세지 "로그인이 완료되었습니다" -> "로그아웃이 완료되었습니다"
- 유저 여부 확인 `api` 주소 "/" -> ""